### PR TITLE
Feature/add daily time goal to category

### DIFF
--- a/__tests__/controllerTest/habitCategoriesControllers/createCategory.test.js
+++ b/__tests__/controllerTest/habitCategoriesControllers/createCategory.test.js
@@ -61,6 +61,89 @@ describe("Create a new habit-category (test route)", () => {
     expect(response.body.message).toBe("Category created successfully.");
     expect(response.body.category.name).toBe(newCategory.habitCategory.name);
     expect(response.body.category.createdAt).toBeDefined(); // createdAt should be set automatically
+    expect(response.body.category.dailyGoal).toBe(0); // dailyGoal should be 0 by default
+  });
+
+  it("should create a new category with a specified dailyGoal", async () => {
+    const newCategory = {
+      habitCategory: {
+        name: "Exercise",
+        dailyGoal: 20,
+      },
+    };
+
+    const response = await request
+      .post("/api/habit-categories/create")
+      .set("Cookie", cookie)
+      .send(newCategory);
+
+    expect(response.status).toBe(201);
+    expect(response.body.success).toBe(true);
+    expect(response.body.message).toBe("Category created successfully.");
+    expect(response.body.category.name).toBe(newCategory.habitCategory.name);
+    expect(response.body.category.dailyGoal).toBe(
+      newCategory.habitCategory.dailyGoal
+    ); // Check that dailyGoal is correctly set
+  });
+
+  it("should fail if the dailyGoal is more than 1440 minutes", async () => {
+    const newCategory = {
+      habitCategory: {
+        name: "Exercise",
+        dailyGoal: 1600, // Exceeds the limit
+      },
+    };
+
+    const response = await request
+      .post("/api/habit-categories/create")
+      .set("Cookie", cookie)
+      .send(newCategory);
+
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
+    expect(response.body.msg).toContain(
+      "BAD REQUEST: Daily goal cannot exceed 1440 minutes (24 hours)."
+    ); // Adjust based on your validation logic
+  });
+
+  it("should fail if the dailyGoal is less than 15 minutes", async () => {
+    const newCategory = {
+      habitCategory: {
+        name: "Exercise",
+        dailyGoal: 14, // Below the minimum
+      },
+    };
+
+    const response = await request
+      .post("/api/habit-categories/create")
+      .set("Cookie", cookie)
+      .send(newCategory);
+
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
+    expect(response.body.msg).toContain(
+      "BAD REQUEST: Daily goal must be at least 15 minutes."
+    ); // Adjust based on your validation logic
+  });
+
+  it("should fail if the dailyGoal is a negative number", async () => {
+    const newCategory = {
+      habitCategory: {
+        name: "Exercise",
+        dailyGoal: -15, // Negative number
+      },
+    };
+
+    const response = await request
+      .post("/api/habit-categories/create")
+      .set("Cookie", cookie)
+      .send(newCategory);
+
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
+    expect(response.body.msg).toContain(
+      "BAD REQUEST: Daily goal must be at least 15 minutes."
+    ); // Adjust based on your validation logic
   });
 
   it("should fail if invalid fields are sent", async () => {

--- a/__tests__/controllerTest/habitCategoriesControllers/getCategory.test.js
+++ b/__tests__/controllerTest/habitCategoriesControllers/getCategory.test.js
@@ -1,0 +1,93 @@
+import supertest from "supertest";
+import {
+  connectToMockDB,
+  closeMockDatabase,
+  clearMockDatabase,
+} from "../../../__testUtils__/dbMock.js";
+import app from "../../../app.js";
+
+const request = supertest(app);
+
+let testUser;
+let cookie;
+
+beforeAll(async () => {
+  // Connect to the mock database and create a test user
+  await connectToMockDB();
+
+  testUser = {
+    name: "Test User",
+    email: "testuser@example.com",
+    password: "Test1234!",
+    dateOfBirth: "Tue Feb 01 1990",
+  };
+
+  // Sign up the test user
+  await request.post("/api/auth/sign-up").send({ user: testUser });
+
+  // Log in to get a session cookie for authenticated requests
+  const loginResponse = await request
+    .post("/api/auth/log-in")
+    .send({ user: { email: testUser.email, password: testUser.password } });
+
+  cookie = loginResponse.headers["set-cookie"];
+
+  // Create several categories for the test user
+  const categories = [
+    { name: "Work", dailyGoal: 90 },
+    { name: "Exercise", dailyGoal: 60 },
+    { name: "Study", dailyGoal: 30 },
+  ];
+
+  await Promise.all(
+    categories.map(async (category) => {
+      await request
+        .post("/api/habit-categories/create")
+        .set("Cookie", cookie)
+        .send({ habitCategory: category });
+    })
+  );
+}, 10000);
+
+afterAll(async () => {
+  // Clear and close the mock database after tests
+  await clearMockDatabase();
+  await closeMockDatabase();
+});
+
+describe("getCategory", () => {
+  it("should return all categories for the authenticated user", async () => {
+    const response = await request
+      .get("/api/habit-categories")
+      .set("Cookie", cookie);
+
+    // Check that the response is successful
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(true);
+
+    // Ensure that the response contains the categories array
+    expect(response.body).toHaveProperty("categories");
+    expect(response.body.categories.length).toBe(3);
+
+    // Check each category's properties
+    response.body.categories.forEach((category) => {
+      expect(category).toHaveProperty("id");
+      expect(category).toHaveProperty("name");
+      expect(category).toHaveProperty("createdAt");
+      expect(category).toHaveProperty("dailyGoal");
+    });
+  });
+
+  it("should return an empty array if the user has no categories", async () => {
+    // Clear categories for this test case
+    await clearMockDatabase();
+
+    const response = await request
+      .get("/api/habit-categories")
+      .set("Cookie", cookie);
+
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(true);
+    expect(response.body.categories).toEqual([]);
+  });
+});

--- a/__tests__/controllerTest/habitCategoriesControllers/getTimeMetricsByDateRange.test.js
+++ b/__tests__/controllerTest/habitCategoriesControllers/getTimeMetricsByDateRange.test.js
@@ -315,6 +315,19 @@ describe("getTimeMetricsByDateRange", () => {
     expect(response.body.categoryData.length).toBe(3);
   });
 
+  it("should return metrics for all categories for a specific year", async () => {
+    const response = await request
+      .get(
+        `/api/habit-categories/date-range-metrics?startDate=2024-01-01&endDate=2024-12-31`
+      )
+      .set("Cookie", cookie);
+
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(true);
+    expect(response.body).toHaveProperty("totalMinutes");
+    expect(response.body.categoryData.length).toBe(3);
+  });
+
   it("should return 400 error if only one of the dates is invalid", async () => {
     const response = await request
       .get(

--- a/__tests__/controllerTest/habitCategoriesControllers/getTimeMetricsByDateRange.test.js
+++ b/__tests__/controllerTest/habitCategoriesControllers/getTimeMetricsByDateRange.test.js
@@ -37,9 +37,9 @@ beforeAll(async () => {
   cookie = loginResponse.headers["set-cookie"];
 
   const categories = [
-    { name: "Work", createdAt: "2024-01-12" },
-    { name: "Exercise", createdAt: "2024-01-12" },
-    { name: "Study", createdAt: "2024-01-12" },
+    { name: "Work", createdAt: "2024-01-12", dailyGoal: 90 },
+    { name: "Exercise", createdAt: "2024-01-12", dailyGoal: 90 },
+    { name: "Study", createdAt: "2024-01-12", dailyGoal: 20 },
   ];
 
   const categoryPromises = categories.map(async (category, index) => {

--- a/__tests__/controllerTest/habitCategoriesControllers/updateCategoryDailyGoal.test.js
+++ b/__tests__/controllerTest/habitCategoriesControllers/updateCategoryDailyGoal.test.js
@@ -1,0 +1,142 @@
+import supertest from "supertest";
+import {
+  connectToMockDB,
+  closeMockDatabase,
+  clearMockDatabase,
+} from "../../../__testUtils__/dbMock.js";
+import app from "../../../app.js";
+
+const request = supertest(app);
+
+beforeAll(async () => {
+  await connectToMockDB();
+});
+
+afterEach(async () => {
+  await clearMockDatabase();
+});
+
+afterAll(async () => {
+  await closeMockDatabase();
+});
+
+describe("Update Daily Goal Tests", () => {
+  let testUser;
+  let cookie;
+  let categoryId;
+  let invalidCategoryId;
+
+  beforeEach(async () => {
+    testUser = {
+      name: "Test User",
+      email: "testuser@example.com",
+      password: "Test1234!",
+      dateOfBirth: "Tue Feb 01 1990",
+    };
+
+    // User sign-up and login
+    await request.post("/api/auth/sign-up").send({ user: testUser });
+
+    const loginResponse = await request
+      .post("/api/auth/log-in")
+      .send({ user: { email: testUser.email, password: testUser.password } });
+
+    cookie = loginResponse.headers["set-cookie"];
+
+    // Create a habit category
+    const newCategory = {
+      habitCategory: { name: "Exercise", dailyGoal: 30 },
+    };
+
+    const categoryResponse = await request
+      .post("/api/habit-categories/create")
+      .set("Cookie", cookie)
+      .send(newCategory);
+
+    categoryId = categoryResponse.body.category._id;
+    invalidCategoryId = "invalidCategoryId";
+  });
+
+  it("should successfully update dailyGoal for a valid category", async () => {
+    const newDailyGoal = 45;
+    const response = await request
+      .patch(`/api/habit-categories/${categoryId}/update-daily-goal`)
+      .set("Cookie", cookie)
+      .send({ dailyGoal: newDailyGoal });
+
+    expect(response.status).toBe(200); // OK
+    expect(response.body.success).toBe(true);
+    expect(response.body.category.dailyGoal).toBe(newDailyGoal);
+  });
+
+  //   it("should return 400 if dailyGoal is missing", async () => {
+  //     const response = await request
+  //       .patch(`/api/habit-categories/${categoryId}/update-daily-goal`)
+  //       .set("Cookie", cookie)
+  //       .send({});
+
+  //     expect(response.status).toBe(400); // Bad Request
+  //     expect(response.body.success).toBe(false);
+  //     expect(response.body.message).toContain("dailyGoal is required.");
+  //   });
+
+  //   it("should return 400 if dailyGoal is not a number", async () => {
+  //     const response = await request
+  //       .patch(`/api/habit-categories/${categoryId}/update-daily-goal`)
+  //       .set("Cookie", cookie)
+  //       .send({ dailyGoal: "notANumber" });
+
+  //     expect(response.status).toBe(400); // Bad Request
+  //     expect(response.body.success).toBe(false);
+  //     expect(response.body.message).toContain("dailyGoal must be a number.");
+  //   });
+
+  //   it("should return 404 if the category is not found", async () => {
+  //     const nonExistentCategoryId = "609b4ec3d1f85b22f0953d91";
+  //     const response = await request
+  //       .patch(`/api/habit-categories/${nonExistentCategoryId}/update-daily-goal`)
+  //       .set("Cookie", cookie)
+  //       .send({ dailyGoal: 45 });
+
+  //     expect(response.status).toBe(404); // Not Found
+  //     expect(response.body.success).toBe(false);
+  //     expect(response.body.message).toContain("Category not found.");
+  //   });
+
+  //   it("should return 403 if the user is not authorized to update the category", async () => {
+  //     // Simulate another user creating a category
+  //     const anotherUser = {
+  //       name: "Another User",
+  //       email: "anotheruser@example.com",
+  //       password: "Another1234!",
+  //       dateOfBirth: "1992-03-03",
+  //     };
+  //     await request.post("/api/auth/sign-up").send({ user: anotherUser });
+  //     const loginResponse = await request.post("/api/auth/log-in").send({
+  //       user: { email: anotherUser.email, password: anotherUser.password },
+  //     });
+  //     const anotherUserCookie = loginResponse.headers["set-cookie"];
+
+  //     const response = await request
+  //       .patch(`/api/habit-categories/${categoryId}/update-daily-goal`)
+  //       .set("Cookie", anotherUserCookie)
+  //       .send({ dailyGoal: 50 });
+
+  //     expect(response.status).toBe(403); // Forbidden
+  //     expect(response.body.success).toBe(false);
+  //     expect(response.body.message).toContain(
+  //       "Forbidden: You are not authorized to update this category."
+  //     );
+  //   });
+
+  //   it("should return 401 if the user is not authenticated", async () => {
+  //     const response = await request
+  //       .patch(`/api/habit-categories/${categoryId}/update-daily-goal`)
+  //       .set("Cookie", "") // No authentication
+  //       .send({ dailyGoal: 45 });
+
+  //     expect(response.status).toBe(401); // Unauthorized
+  //     expect(response.body.success).toBe(false);
+  //     expect(response.body.message).toContain("Authentication required.");
+  //   });
+});

--- a/__tests__/controllerTest/habitCategoriesControllers/updateCategoryDailyGoal.test.js
+++ b/__tests__/controllerTest/habitCategoriesControllers/updateCategoryDailyGoal.test.js
@@ -69,74 +69,182 @@ describe("Update Daily Goal Tests", () => {
     expect(response.body.category.dailyGoal).toBe(newDailyGoal);
   });
 
-  //   it("should return 400 if dailyGoal is missing", async () => {
-  //     const response = await request
-  //       .patch(`/api/habit-categories/${categoryId}/update-daily-goal`)
-  //       .set("Cookie", cookie)
-  //       .send({});
+  it("should return 400 if dailyGoal is missing", async () => {
+    const response = await request
+      .patch(`/api/habit-categories/${categoryId}/update-daily-goal`)
+      .set("Cookie", cookie)
+      .send({});
 
-  //     expect(response.status).toBe(400); // Bad Request
-  //     expect(response.body.success).toBe(false);
-  //     expect(response.body.message).toContain("dailyGoal is required.");
-  //   });
+    expect(response.status).toBe(400); // Bad Request
+    expect(response.body.success).toBe(false);
+    expect(response.body.message).toContain("dailyGoal is required.");
+  });
 
-  //   it("should return 400 if dailyGoal is not a number", async () => {
-  //     const response = await request
-  //       .patch(`/api/habit-categories/${categoryId}/update-daily-goal`)
-  //       .set("Cookie", cookie)
-  //       .send({ dailyGoal: "notANumber" });
+  it("should return 400 if dailyGoal is not a number", async () => {
+    const response = await request
+      .patch(`/api/habit-categories/${categoryId}/update-daily-goal`)
+      .set("Cookie", cookie)
+      .send({ dailyGoal: "notANumber" });
 
-  //     expect(response.status).toBe(400); // Bad Request
-  //     expect(response.body.success).toBe(false);
-  //     expect(response.body.message).toContain("dailyGoal must be a number.");
-  //   });
+    expect(response.status).toBe(400); // Bad Request
+    expect(response.body.success).toBe(false);
+    expect(response.body.message).toContain(
+      "BAD REQUEST: Daily goal must be an integer."
+    );
+  });
 
-  //   it("should return 404 if the category is not found", async () => {
-  //     const nonExistentCategoryId = "609b4ec3d1f85b22f0953d91";
-  //     const response = await request
-  //       .patch(`/api/habit-categories/${nonExistentCategoryId}/update-daily-goal`)
-  //       .set("Cookie", cookie)
-  //       .send({ dailyGoal: 45 });
+  it("should return 404 if the category is not found", async () => {
+    const nonExistentCategoryId = "609b4ec3d1f85b22f0953d91";
+    const response = await request
+      .patch(`/api/habit-categories/${nonExistentCategoryId}/update-daily-goal`)
+      .set("Cookie", cookie)
+      .send({ dailyGoal: 45 });
 
-  //     expect(response.status).toBe(404); // Not Found
-  //     expect(response.body.success).toBe(false);
-  //     expect(response.body.message).toContain("Category not found.");
-  //   });
+    expect(response.status).toBe(404); // Not Found
+    expect(response.body.success).toBe(false);
+    expect(response.body.message).toContain("Category not found.");
+  });
 
-  //   it("should return 403 if the user is not authorized to update the category", async () => {
-  //     // Simulate another user creating a category
-  //     const anotherUser = {
-  //       name: "Another User",
-  //       email: "anotheruser@example.com",
-  //       password: "Another1234!",
-  //       dateOfBirth: "1992-03-03",
-  //     };
-  //     await request.post("/api/auth/sign-up").send({ user: anotherUser });
-  //     const loginResponse = await request.post("/api/auth/log-in").send({
-  //       user: { email: anotherUser.email, password: anotherUser.password },
-  //     });
-  //     const anotherUserCookie = loginResponse.headers["set-cookie"];
+  it("should return 403 if the user is not authorized to update the category", async () => {
+    // Simulate another user creating a category
+    const anotherUser = {
+      name: "Another User",
+      email: "anotheruser@example.com",
+      password: "Another1234!",
+      dateOfBirth: "Tue Feb 01 1992",
+    };
 
-  //     const response = await request
-  //       .patch(`/api/habit-categories/${categoryId}/update-daily-goal`)
-  //       .set("Cookie", anotherUserCookie)
-  //       .send({ dailyGoal: 50 });
+    await request.post("/api/auth/sign-up").send({ user: anotherUser });
 
-  //     expect(response.status).toBe(403); // Forbidden
-  //     expect(response.body.success).toBe(false);
-  //     expect(response.body.message).toContain(
-  //       "Forbidden: You are not authorized to update this category."
-  //     );
-  //   });
+    const loginResponse = await request.post("/api/auth/log-in").send({
+      user: { email: anotherUser.email, password: anotherUser.password },
+    });
 
-  //   it("should return 401 if the user is not authenticated", async () => {
-  //     const response = await request
-  //       .patch(`/api/habit-categories/${categoryId}/update-daily-goal`)
-  //       .set("Cookie", "") // No authentication
-  //       .send({ dailyGoal: 45 });
+    const anotherUserCookie = loginResponse.headers["set-cookie"];
 
-  //     expect(response.status).toBe(401); // Unauthorized
-  //     expect(response.body.success).toBe(false);
-  //     expect(response.body.message).toContain("Authentication required.");
-  //   });
+    const response = await request
+      .patch(`/api/habit-categories/${categoryId}/update-daily-goal`)
+      .set("Cookie", anotherUserCookie)
+      .send({ dailyGoal: 50 });
+
+    expect(response.status).toBe(403); // Forbidden
+    expect(response.body.success).toBe(false);
+    expect(response.body.message).toContain(
+      "Forbidden: You are not authorized to update this category."
+    );
+  });
+
+  it("should return 401 if the user is not authenticated", async () => {
+    const response = await request
+      .patch(`/api/habit-categories/${categoryId}/update-daily-goal`)
+      .set("Cookie", "") // No authentication
+      .send({ dailyGoal: 45 });
+
+    expect(response.status).toBe(401); // Unauthorized
+    expect(response.body.success).toBe(false);
+    expect(response.body.msg).toContain("Authentication required.");
+  });
+
+  it("should allow updating dailyGoal to the minimum allowed value", async () => {
+    const response = await request
+      .patch(`/api/habit-categories/${categoryId}/update-daily-goal`)
+      .set("Cookie", cookie)
+      .send({ dailyGoal: 15 });
+
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(true);
+    expect(response.body.category.dailyGoal).toBe(15);
+  });
+
+  it("should allow updating dailyGoal to the maximum allowed value", async () => {
+    const response = await request
+      .patch(`/api/habit-categories/${categoryId}/update-daily-goal`)
+      .set("Cookie", cookie)
+      .send({ dailyGoal: 1440 });
+
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(true);
+    expect(response.body.category.dailyGoal).toBe(1440);
+  });
+
+  it("should return 400 if dailyGoal is below the minimum allowed value", async () => {
+    const response = await request
+      .patch(`/api/habit-categories/${categoryId}/update-daily-goal`)
+      .set("Cookie", cookie)
+      .send({ dailyGoal: 14 });
+
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
+    expect(response.body.message).toContain(
+      "Daily goal must be at least 15 minutes."
+    );
+  });
+
+  it("should return 400 if dailyGoal is above the maximum allowed value", async () => {
+    const response = await request
+      .patch(`/api/habit-categories/${categoryId}/update-daily-goal`)
+      .set("Cookie", cookie)
+      .send({ dailyGoal: 1441 });
+
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
+    expect(response.body.message).toContain(
+      "Daily goal cannot exceed 1440 minutes (24 hours)."
+    );
+  });
+
+  it("should return 400 if dailyGoal is null", async () => {
+    const response = await request
+      .patch(`/api/habit-categories/${categoryId}/update-daily-goal`)
+      .set("Cookie", cookie)
+      .send({ dailyGoal: null });
+
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
+    expect(response.body.message).toContain("dailyGoal is required.");
+  });
+
+  it("should return 400 if dailyGoal is an empty string", async () => {
+    const response = await request
+      .patch(`/api/habit-categories/${categoryId}/update-daily-goal`)
+      .set("Cookie", cookie)
+      .send({ dailyGoal: "" });
+
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
+    expect(response.body.message).toContain("dailyGoal is required.");
+  });
+
+  it("should return 400 if dailyGoal is an object", async () => {
+    const response = await request
+      .patch(`/api/habit-categories/${categoryId}/update-daily-goal`)
+      .set("Cookie", cookie)
+      .send({ dailyGoal: {} });
+
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
+    expect(response.body.message).toContain("Daily goal must be an integer.");
+  });
+
+  it("should return 400 if dailyGoal is an array", async () => {
+    const response = await request
+      .patch(`/api/habit-categories/${categoryId}/update-daily-goal`)
+      .set("Cookie", cookie)
+      .send({ dailyGoal: [] });
+
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
+    expect(response.body.message).toContain("Daily goal must be an integer.");
+  });
+
+  it("should return 400 if the category ID is in an invalid format", async () => {
+    const response = await request
+      .patch(`/api/habit-categories/invalid-id/update-daily-goal`)
+      .set("Cookie", cookie)
+      .send({ dailyGoal: 30 });
+
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
+    expect(response.body.message).toContain("Invalid category ID.");
+  });
 });

--- a/__tests__/modelsTest/validateCategory.test.js
+++ b/__tests__/modelsTest/validateCategory.test.js
@@ -8,11 +8,43 @@ describe("validateCategory function", () => {
       createdAt: new Date(),
       createdBy: new mongoose.Types.ObjectId(),
       categoryId: new mongoose.Types.ObjectId(),
+      dailyGoal: 60, // Valid dailyGoal in minutes
     };
 
     const errors = validateCategory(category);
-
     expect(errors).toHaveLength(0);
+  });
+
+  test("should return an error if 'dailyGoal' is below the minimum value", () => {
+    const category = {
+      name: "Fitness",
+      dailyGoal: 14, // Below the minimum of 15 minutes
+    };
+
+    const errors = validateCategory(category);
+    expect(errors).toContain("Daily goal must be at least 15 minutes.");
+  });
+
+  test("should return an error if 'dailyGoal' is not an integer", () => {
+    const category = {
+      name: "Fitness",
+      dailyGoal: 45.5, // Not an integer
+    };
+
+    const errors = validateCategory(category);
+    expect(errors).toContain("Daily goal must be an integer.");
+  });
+
+  test("should return an error if 'dailyGoal' exceeds the maximum value", () => {
+    const category = {
+      name: "Fitness",
+      dailyGoal: 1500, // Above the maximum of 1440 minutes (24 hours)
+    };
+
+    const errors = validateCategory(category);
+    expect(errors).toContain(
+      "Daily goal cannot exceed 1440 minutes (24 hours)."
+    );
   });
 
   test("should return an array with error messages if required fields are missing", () => {
@@ -21,6 +53,37 @@ describe("validateCategory function", () => {
     const errors = validateCategory(category);
 
     expect(errors).toContain("Category name is required.");
+  });
+
+  test("should pass if 'dailyGoal' is exactly at the minimum value", () => {
+    const category = {
+      name: "Fitness",
+      dailyGoal: 30, // Minimum allowed value
+    };
+
+    const errors = validateCategory(category);
+    expect(errors).toHaveLength(0);
+  });
+
+  test("should pass if 'dailyGoal' is exactly at the maximum value", () => {
+    const category = {
+      name: "Fitness",
+      dailyGoal: 1440, // Maximum allowed value
+    };
+
+    const errors = validateCategory(category);
+    expect(errors).toHaveLength(0);
+  });
+
+  test("should pass if 'dailyGoal' is not provided (optional field)", () => {
+    const category = {
+      name: "Fitness",
+      createdBy: new mongoose.Types.ObjectId(),
+      createdAt: new Date(),
+    };
+
+    const errors = validateCategory(category);
+    expect(errors).toHaveLength(0);
   });
 
   test("should return an error message if the name is null", () => {

--- a/controllers/habitCategoriesControllers/createCategory.js
+++ b/controllers/habitCategoriesControllers/createCategory.js
@@ -41,11 +41,15 @@ export const createCategory = async (req, res) => {
     // Set createdAt if not provided
     const finalCreatedAt = habitCategory.createdAt || Date.now();
 
+    // Set dailyGoal, defaulting to 0 if not provided
+    const dailyGoal = habitCategory.dailyGoal || 0;
+
     // Create new habit category
     const newCategory = new HabitCategory({
       name: habitCategory.name,
       createdBy: userId,
       createdAt: finalCreatedAt,
+      dailyGoal: dailyGoal,
     });
 
     // Save the new category

--- a/controllers/habitCategoriesControllers/getCategory.js
+++ b/controllers/habitCategoriesControllers/getCategory.js
@@ -1,0 +1,46 @@
+import HabitCategory from "../../models/habitCategory.js";
+import { logInfo, logError } from "../../util/logging.js";
+
+// Controller to retrieve all habit categories for a user
+export const getCategory = async (req, res) => {
+  const userId = req.userId;
+
+  try {
+    // Find all categories created by the user
+    const userCategories = await HabitCategory.find({ createdBy: userId });
+
+    // If no categories exist, return an empty array with a success message
+    if (!userCategories || userCategories.length === 0) {
+      return res.status(200).json({
+        success: true,
+        msg: "No categories found for this user, but the request was successful.",
+        categories: [],
+      });
+    }
+
+    // Map categories to a simplified structure
+    const categoryData = userCategories.map((category) => ({
+      id: category._id,
+      name: category.name,
+      createdAt: category.createdAt,
+      dailyGoal: category.dailyGoal || 0, // Set default dailyGoal to 0 if undefined
+    }));
+
+    // Log the retrieval success
+    logInfo(`Categories retrieved successfully for user ${userId}`);
+
+    // Return a response containing all user categories
+    return res.status(200).json({
+      success: true,
+      categories: categoryData,
+    });
+  } catch (error) {
+    // Log any errors that occur during category retrieval
+    logError(`Error fetching categories: ${error.message}`);
+    return res.status(500).json({
+      success: false,
+      message: "Error fetching categories.",
+      error: error.message,
+    });
+  }
+};

--- a/controllers/habitCategoriesControllers/updateCategoryDailyGoal.js
+++ b/controllers/habitCategoriesControllers/updateCategoryDailyGoal.js
@@ -1,0 +1,76 @@
+import mongoose from "mongoose";
+import HabitCategory, { validateCategory } from "../../models/habitCategory.js";
+import { logError } from "../../util/logging.js";
+import validateAllowedFields from "../../util/validateAllowedFields.js";
+import validationErrorMessage from "../../util/validationErrorMessage.js";
+
+export const updateCategoryDailyGoal = async (req, res) => {
+  const { categoryId } = req.params;
+  const { dailyGoal: newDailyGoal } = req.body;
+  const createdBy = req.userId;
+  const allowedFields = ["dailyGoal"];
+
+  // Validate the category ID
+  if (!mongoose.Types.ObjectId.isValid(categoryId)) {
+    return res.status(400).json({
+      success: false,
+      message: "BAD REQUEST: Invalid category ID.",
+    });
+  }
+
+  // Validate allowed fields
+  const invalidFieldsError = validateAllowedFields(req.body, allowedFields);
+  if (invalidFieldsError) {
+    return res.status(400).json({
+      success: false,
+      message: `BAD REQUEST: ${invalidFieldsError}`,
+    });
+  }
+
+  try {
+    const category = await HabitCategory.findById(categoryId);
+    if (!category) {
+      return res.status(404).json({
+        success: false,
+        message: "Category not found.",
+      });
+    }
+
+    // Verify if the user is authorized to update the category
+    if (category.createdBy.toString() !== createdBy.toString()) {
+      return res.status(403).json({
+        success: false,
+        message: "Forbidden: You are not authorized to update this category.",
+      });
+    }
+
+    // Validate the new dailyGoal
+    const errorList = validateCategory({
+      name: category.name,
+      dailyGoal: newDailyGoal,
+    });
+    if (errorList.length > 0) {
+      return res.status(400).json({
+        success: false,
+        message: validationErrorMessage(errorList),
+      });
+    }
+
+    // Update the dailyGoal
+    category.dailyGoal = newDailyGoal;
+    await category.save();
+
+    return res.status(200).json({
+      success: true,
+      message: "Category daily goal updated successfully.",
+      category,
+    });
+  } catch (error) {
+    logError(`Error updating category daily goal: ${error}`);
+    return res.status(500).json({
+      success: false,
+      message: "Error updating category daily goal.",
+      error: validationErrorMessage([error.message]),
+    });
+  }
+};

--- a/controllers/habitCategoriesControllers/updateCategoryDailyGoal.js
+++ b/controllers/habitCategoriesControllers/updateCategoryDailyGoal.js
@@ -18,6 +18,18 @@ export const updateCategoryDailyGoal = async (req, res) => {
     });
   }
 
+  // Validate that dailyGoal is provided
+  if (
+    newDailyGoal === undefined ||
+    newDailyGoal === null ||
+    newDailyGoal === ""
+  ) {
+    return res.status(400).json({
+      success: false,
+      message: "BAD REQUEST: dailyGoal is required.",
+    });
+  }
+
   // Validate allowed fields
   const invalidFieldsError = validateAllowedFields(req.body, allowedFields);
   if (invalidFieldsError) {

--- a/models/habitCategory.js
+++ b/models/habitCategory.js
@@ -19,12 +19,22 @@ const habitCategorySchema = new mongoose.Schema({
     default: Date.now,
     required: true,
   },
+  dailyGoal: {
+    type: Number,
+    default: 0,
+  },
 });
 
 // Validation function for the category
 export const validateCategory = (categoryObject, requireName = true) => {
   const errorList = [];
-  const allowedKeys = ["name", "createdBy", "createdAt", "categoryId"];
+  const allowedKeys = [
+    "name",
+    "createdBy",
+    "createdAt",
+    "categoryId",
+    "dailyGoal",
+  ];
 
   // Validate allowed fields
   const validatedKeysMessage = validateAllowedFields(
@@ -66,6 +76,20 @@ export const validateCategory = (categoryObject, requireName = true) => {
     !mongoose.Types.ObjectId.isValid(categoryObject.categoryId)
   ) {
     errorList.push("Invalid 'categoryId' provided.");
+  }
+
+  // Validate 'dailyGoal' as a number in the valid range
+  if (categoryObject.dailyGoal) {
+    if (
+      typeof categoryObject.dailyGoal !== "number" ||
+      !Number.isInteger(categoryObject.dailyGoal)
+    ) {
+      errorList.push("Daily goal must be an integer.");
+    } else if (categoryObject.dailyGoal < 30) {
+      errorList.push("Daily goal must be at least 30 minutes.");
+    } else if (categoryObject.dailyGoal > 1440) {
+      errorList.push("Daily goal cannot exceed 1440 minutes (24 hours).");
+    }
   }
 
   // Log validation results

--- a/models/habitCategory.js
+++ b/models/habitCategory.js
@@ -78,8 +78,8 @@ export const validateCategory = (categoryObject, requireName = true) => {
     errorList.push("Invalid 'categoryId' provided.");
   }
 
-  // Validate 'dailyGoal' as a number in the valid range
-  if (categoryObject.dailyGoal) {
+  // Validate 'dailyGoal' range
+  if (categoryObject.dailyGoal !== undefined) {
     if (
       typeof categoryObject.dailyGoal !== "number" ||
       !Number.isInteger(categoryObject.dailyGoal)

--- a/models/habitCategory.js
+++ b/models/habitCategory.js
@@ -85,8 +85,8 @@ export const validateCategory = (categoryObject, requireName = true) => {
       !Number.isInteger(categoryObject.dailyGoal)
     ) {
       errorList.push("Daily goal must be an integer.");
-    } else if (categoryObject.dailyGoal < 30) {
-      errorList.push("Daily goal must be at least 30 minutes.");
+    } else if (categoryObject.dailyGoal < 15) {
+      errorList.push("Daily goal must be at least 15 minutes.");
     } else if (categoryObject.dailyGoal > 1440) {
       errorList.push("Daily goal cannot exceed 1440 minutes (24 hours).");
     }

--- a/routes/habitCategoriesRouter.js
+++ b/routes/habitCategoriesRouter.js
@@ -5,6 +5,7 @@ import { deleteCategory } from "../controllers/habitCategoriesControllers/delete
 import { getTimeMetricsByDateRange } from "../controllers/habitCategoriesControllers/getTimeMetricsByDateRange.js";
 import { getMonthlyTimeMetrics } from "../controllers/habitCategoriesControllers/getMonthlyTimeMetrics.js";
 import { getWeeklyTimeMetrics } from "../controllers/habitCategoriesControllers/getWeeklyTimeMetrics.js";
+import { getCategory } from "../controllers/habitCategoriesControllers/getCategory.js";
 
 const habitCategoriesRouter = express.Router();
 
@@ -15,5 +16,6 @@ habitCategoriesRouter.delete("/:categoryId", deleteCategory);
 habitCategoriesRouter.get("/date-range-metrics", getTimeMetricsByDateRange);
 habitCategoriesRouter.get("/monthly-metrics", getMonthlyTimeMetrics);
 habitCategoriesRouter.get("/weekly-metrics", getWeeklyTimeMetrics);
+habitCategoriesRouter.get("/", getCategory);
 
 export default habitCategoriesRouter;

--- a/routes/habitCategoriesRouter.js
+++ b/routes/habitCategoriesRouter.js
@@ -6,12 +6,17 @@ import { getTimeMetricsByDateRange } from "../controllers/habitCategoriesControl
 import { getMonthlyTimeMetrics } from "../controllers/habitCategoriesControllers/getMonthlyTimeMetrics.js";
 import { getWeeklyTimeMetrics } from "../controllers/habitCategoriesControllers/getWeeklyTimeMetrics.js";
 import { getCategory } from "../controllers/habitCategoriesControllers/getCategory.js";
+import { updateCategoryDailyGoal } from "../controllers/habitCategoriesControllers/updateCategoryDailyGoal.js";
 
 const habitCategoriesRouter = express.Router();
 
 habitCategoriesRouter.post("/create", createCategory);
 habitCategoriesRouter.patch("/:categoryId/name", updateCategoryName);
 habitCategoriesRouter.delete("/:categoryId", deleteCategory);
+habitCategoriesRouter.patch(
+  "/:categoryId/update-daily-goal",
+  updateCategoryDailyGoal
+);
 
 habitCategoriesRouter.get("/date-range-metrics", getTimeMetricsByDateRange);
 habitCategoriesRouter.get("/monthly-metrics", getMonthlyTimeMetrics);


### PR DESCRIPTION
Summary:

New Route Added: getCategories

Introduced a new GET endpoint to retrieve all categories associated with the authenticated user. This route returns a list of the user’s habit categories, allowing users to view their categories collectively.
Schema Update: dailyGoal Field in HabitCategory

Added a dailyGoal field to the HabitCategory schema, representing the daily time goal in minutes for each habit category. The dailyGoal field defaults to 0 if not specified by the user.
New Route Added: updateCategoryDailyGoals

Created an PATCH endpoint to allow users to update the dailyGoal field for specific categories. This endpoint includes validation to ensure only valid integer values are set, with constraints to avoid negative or overly high values.
Test Suites Added: Coverage for New Endpoints

Comprehensive tests created for both getCategories and updateCategoryDailyGoals endpoints to ensure reliable, accurate behavior across various scenarios.