### PR TITLE
fix(auth): handle new user creation and response flow in Google sign-in controller

### DIFF
--- a/controllers/authControllers/signInWithGoogleController.js
+++ b/controllers/authControllers/signInWithGoogleController.js
@@ -36,7 +36,8 @@ export const signInWithGoogleController = async (req, res) => {
         user = new User({ name, email, picture, password });
         await user.save();
         isNewUser = true;
-        await sendWelcomeEmail(user, res);
+
+        await sendWelcomeEmail(user);
         logInfo(`New Web user created: ${user.email}`);
       }
 
@@ -90,11 +91,13 @@ export const signInWithGoogleController = async (req, res) => {
     let user = await User.findOne({ email });
 
     try {
+      user = await User.findOne({ email });
+
       if (!user) {
         user = new User({ name, email, picture });
         await user.save();
         isNewUser = true;
-        await sendWelcomeEmail(user, res);
+        await sendWelcomeEmail(user);
       }
     } catch (userError) {
       logError("User creation error: " + userError.message);


### PR DESCRIPTION
- Ensure single response is sent when creating a new user, avoiding double responses
- Add error handling to manage category creation errors independently from user creation
- Simplify response structure for better consistency across new and existing users
- Update tests to validate new user creation, token issuance, and default category setup

This fix addresses issues with double response errors on Heroku and improves reliability in user creation flow.