### PR TITLE
Add route for creating default categories

### DIFF
--- a/__tests__/controllerTest/habitCategoriesControllers/autoCreateCategoriesController.test.js
+++ b/__tests__/controllerTest/habitCategoriesControllers/autoCreateCategoriesController.test.js
@@ -1,0 +1,61 @@
+import supertest from "supertest";
+import {
+  connectToMockDB,
+  closeMockDatabase,
+  clearMockDatabase,
+} from "../../../__testUtils__/dbMock.js";
+import app from "../../../app.js";
+import { logInfo } from "../../../util/logging.js";
+
+const request = supertest(app);
+
+beforeAll(async () => {
+  await connectToMockDB();
+});
+
+afterEach(async () => {
+  await clearMockDatabase();
+});
+
+afterAll(async () => {
+  await closeMockDatabase();
+});
+
+describe("Create a new habit-category (test route)", () => {
+  let testUser;
+  let cookie;
+
+  beforeEach(async () => {
+    testUser = {
+      name: "Test User",
+      email: "testuser@example.com",
+      password: "Test1234!",
+      dateOfBirth: "Tue Feb 01 1990",
+    };
+
+    // User sign-up
+    await request.post("/api/auth/sign-up").send({ user: testUser });
+
+    // User login
+    const loginResponse = await request
+      .post("/api/auth/log-in")
+      .send({ user: { email: testUser.email, password: testUser.password } });
+
+    cookie = loginResponse.headers["set-cookie"];
+
+    // delete the default categories
+    await request
+      .delete("/api/habit-categories/delete-all-categories")
+      .set("Cookie", cookie);
+  });
+
+  it("should create default categories if then does not exist", async () => {
+    const response = await request
+      .post("/api/habit-categories/auto-create-categories")
+      .set("Cookie", cookie);
+
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(true);
+    expect(response.body.message).toBe("Categories created successfully.");
+  });
+});

--- a/__tests__/controllerTest/habitCategoriesControllers/getCategory.test.js
+++ b/__tests__/controllerTest/habitCategoriesControllers/getCategory.test.js
@@ -73,5 +73,8 @@ describe("getCategory", () => {
     expect(response.status).toBe(200);
     expect(response.body.success).toBe(true);
     expect(response.body.categories).toEqual([]);
+    expect(response.body.msg).toBe(
+      "No categories found for this user, but the request was successful."
+    );
   });
 });

--- a/controllers/authControllers/logoutController.js
+++ b/controllers/authControllers/logoutController.js
@@ -25,19 +25,22 @@ export const logout = (req, res) => {
     // Clear cookies for mobile users
     if (req.cookies.session) {
       res.clearCookie("session", { httpOnly: true, secure: true });
-      res.clearCookie("zenTimerToken", { httpOnly: true, secure: true }); // Add other relevant cookies
+      res.clearCookie("zenTimerToken", { httpOnly: true, secure: true });
     }
 
-    // Log out action for web users using token (if applicable)
     if (req.headers["authorization"]) {
       // Here you could implement any logic related to invalidating the token if necessary
       // For example: invalidateToken(req.headers['authorization']);
-      console.log("User is logged out via token");
+      logInfo("User is logged out via token");
     }
 
-    logInfo(`User with ID ${req.user.id} successfully logged out.`);
+    // Log the user logout
+    logInfo(`User with ID ${req.userId} successfully logged out.`);
 
-    res.status(204).send(); // No content response
+    res.status(200).json({
+      success: true,
+      message: "User successfully logged out",
+    });
   } catch (error) {
     logError("Logout error: ", error);
     res.status(500).json({

--- a/controllers/authControllers/logoutController.js
+++ b/controllers/authControllers/logoutController.js
@@ -2,32 +2,47 @@ import { logInfo, logError } from "../../util/logging.js";
 
 export const logout = (req, res) => {
   try {
-    console.log("Current cookies:", req.cookies);
-
-    // Check for active session
-    if (!req.cookies.session) {
-      return res
-        .status(400)
-        .json({
-          success: false,
-          message: "No active session to log out from.",
-        });
+    // Check if cookies exist and log them, otherwise log the token if available
+    if (Object.keys(req.cookies).length > 0) {
+      console.log("Current cookies:", req.cookies);
+    } else if (req.headers["authorization"]) {
+      console.log(
+        "No cookies found, but found token:",
+        req.headers["authorization"]
+      );
+    } else {
+      console.log("No cookies or token found.");
     }
 
-    // Clear cookies
-    res.clearCookie("session", { httpOnly: true, secure: true });
-    res.clearCookie("zenTimerToken", { httpOnly: true, secure: true }); // Add other relevant cookies
+    // Check for active session (either cookie or token)
+    if (!req.cookies.session && !req.headers["authorization"]) {
+      return res.status(400).json({
+        success: false,
+        message: "No active session or token to log out from.",
+      });
+    }
+
+    // Clear cookies for mobile users
+    if (req.cookies.session) {
+      res.clearCookie("session", { httpOnly: true, secure: true });
+      res.clearCookie("zenTimerToken", { httpOnly: true, secure: true }); // Add other relevant cookies
+    }
+
+    // Log out action for web users using token (if applicable)
+    if (req.headers["authorization"]) {
+      // Here you could implement any logic related to invalidating the token if necessary
+      // For example: invalidateToken(req.headers['authorization']);
+      console.log("User is logged out via token");
+    }
 
     logInfo(`User with ID ${req.user.id} successfully logged out.`);
 
     res.status(204).send(); // No content response
   } catch (error) {
     logError("Logout error: ", error);
-    res
-      .status(500)
-      .json({
-        success: false,
-        message: error.message || "An error occurred during logout",
-      });
+    res.status(500).json({
+      success: false,
+      message: error.message || "An error occurred during logout",
+    });
   }
 };

--- a/controllers/authControllers/logoutController.js
+++ b/controllers/authControllers/logoutController.js
@@ -4,14 +4,14 @@ export const logout = (req, res) => {
   try {
     // Check if cookies exist and log them, otherwise log the token if available
     if (Object.keys(req.cookies).length > 0) {
-      console.log("Current cookies:", req.cookies);
+      logInfo("Current cookies:", req.cookies);
     } else if (req.headers["authorization"]) {
-      console.log(
+      logInfo(
         "No cookies found, but found token:",
         req.headers["authorization"]
       );
     } else {
-      console.log("No cookies or token found.");
+      logInfo("No cookies or token found.");
     }
 
     // Check for active session (either cookie or token)

--- a/controllers/habitCategoriesControllers/autoCreateDefaultCategories.js
+++ b/controllers/habitCategoriesControllers/autoCreateDefaultCategories.js
@@ -1,0 +1,19 @@
+import { autoCreateDefaultCategories } from "../../util/autoCreateDefaultCategories";
+import { logError } from "../../util/logging";
+
+export const autoCreateCategoriesController = async (req, res) => {
+  try {
+    const userId = req.userId;
+
+    if (!userId) {
+      return res.status(400).json({ message: "User ID is required" });
+    }
+
+    await autoCreateDefaultCategories(userId);
+
+    return res.status(200).json({ message: "Categories created successfully" });
+  } catch (error) {
+    logError("Error in autoCreateCategoriesController:", error);
+    return res.status(500).json({ message: "Internal server error" });
+  }
+};

--- a/controllers/habitCategoriesControllers/autoCreateDefaultCategories.js
+++ b/controllers/habitCategoriesControllers/autoCreateDefaultCategories.js
@@ -6,12 +6,16 @@ export const autoCreateCategoriesController = async (req, res) => {
     const userId = req.userId;
 
     if (!userId) {
-      return res.status(400).json({ message: "User ID is required" });
+      return res
+        .status(400)
+        .json({ success: false, message: "User ID is required." });
     }
 
     await autoCreateDefaultCategories(userId);
 
-    return res.status(200).json({ message: "Categories created successfully" });
+    return res
+      .status(200)
+      .json({ success: true, message: "Categories created successfully." });
   } catch (error) {
     logError("Error in autoCreateCategoriesController:", error);
     return res.status(500).json({ message: "Internal server error" });

--- a/controllers/habitCategoriesControllers/autoCreateDefaultCategoriesController.js
+++ b/controllers/habitCategoriesControllers/autoCreateDefaultCategoriesController.js
@@ -1,7 +1,7 @@
-import { autoCreateDefaultCategories } from "../../util/autoCreateDefaultCategories";
-import { logError } from "../../util/logging";
+import { autoCreateDefaultCategories } from "../../util/autoCreateDefaultCategories.js";
+import { logError } from "../../util/logging.js";
 
-export const autoCreateCategoriesController = async (req, res) => {
+export const autoCreateDefaultCategoriesController = async (req, res) => {
   try {
     const userId = req.userId;
 

--- a/middleware/authMiddleware.js
+++ b/middleware/authMiddleware.js
@@ -6,7 +6,7 @@ export const requireAuth = (req, res, next) => {
   const session = req.cookies.session;
   const authHeader = req.headers.authorization;
 
-  logInfo("Verifying token in session cookie or Authorization header...");
+  // logInfo("Verifying token in session cookie or Authorization header...");
 
   // Helper function to verify the token and authenticate the user
   const verifyToken = (token) => {

--- a/routes/authRoutes.js
+++ b/routes/authRoutes.js
@@ -2,7 +2,7 @@ import express from "express";
 import { signup } from "../controllers/authControllers/signupController.js";
 import { signInWithGoogleController } from "../controllers/authControllers/signInWithGoogleController.js";
 import { login } from "../controllers/authControllers/loginController.js";
-import { logout } from "../controllers/authControllers/logoutController.js";
+// import { logout } from "../controllers/authControllers/logoutController.js";
 import {
   resendVerificationLink,
   verifyEmail,
@@ -13,7 +13,7 @@ const authRouter = express.Router();
 authRouter.post("/sign-up", signup);
 authRouter.post("/sign-in-with-google", signInWithGoogleController);
 authRouter.post("/log-in", login);
-authRouter.post("/log-out", logout);
+// authRouter.post("/log-out", logout);
 
 authRouter.post("/resend-verification-link", resendVerificationLink);
 authRouter.get("/verify/:userId/:uniqueString", verifyEmail);

--- a/routes/habitCategoriesRouter.js
+++ b/routes/habitCategoriesRouter.js
@@ -1,6 +1,6 @@
 import express from "express";
 import { createCategory } from "../controllers/habitCategoriesControllers/createCategory.js";
-import { autoCreateCategoriesController } from "../controllers/habitCategoriesControllers/autoCreateDefaultCategories.js";
+import { autoCreateDefaultCategoriesController } from "../controllers/habitCategoriesControllers/autoCreateDefaultCategoriesController.js";
 import { updateCategoryName } from "../controllers/habitCategoriesControllers/updateCategoryName.js";
 import { deleteCategory } from "../controllers/habitCategoriesControllers/deleteCategory.js";
 import { getTimeMetricsByDateRange } from "../controllers/habitCategoriesControllers/getTimeMetricsByDateRange.js";
@@ -16,7 +16,7 @@ habitCategoriesRouter.post("/create", createCategory);
 habitCategoriesRouter.patch("/:categoryId/name", updateCategoryName);
 habitCategoriesRouter.post(
   "/auto-create-categories",
-  autoCreateCategoriesController
+  autoCreateDefaultCategoriesController
 );
 
 habitCategoriesRouter.delete("/delete-all-categories", deleteAllCategories);

--- a/routes/habitCategoriesRouter.js
+++ b/routes/habitCategoriesRouter.js
@@ -1,5 +1,6 @@
 import express from "express";
 import { createCategory } from "../controllers/habitCategoriesControllers/createCategory.js";
+import { autoCreateCategoriesController } from "../controllers/habitCategoriesControllers/autoCreateDefaultCategories.js";
 import { updateCategoryName } from "../controllers/habitCategoriesControllers/updateCategoryName.js";
 import { deleteCategory } from "../controllers/habitCategoriesControllers/deleteCategory.js";
 import { getTimeMetricsByDateRange } from "../controllers/habitCategoriesControllers/getTimeMetricsByDateRange.js";
@@ -13,6 +14,10 @@ const habitCategoriesRouter = express.Router();
 
 habitCategoriesRouter.post("/create", createCategory);
 habitCategoriesRouter.patch("/:categoryId/name", updateCategoryName);
+habitCategoriesRouter.post(
+  "/auto-create-categories",
+  autoCreateCategoriesController
+);
 
 habitCategoriesRouter.delete("/delete-all-categories", deleteAllCategories);
 habitCategoriesRouter.delete("/:categoryId", deleteCategory);

--- a/routes/userRoutes.js
+++ b/routes/userRoutes.js
@@ -1,8 +1,10 @@
 import express from "express";
 import { getUsers } from "../controllers/userController.js";
+import { logout } from "../controllers/authControllers/logoutController.js";
 
 const userRouter = express.Router();
 
 userRouter.get("/", getUsers);
+userRouter.post("/log-out", logout);
 
 export default userRouter;

--- a/util/autoCreateDefaultCategories.js
+++ b/util/autoCreateDefaultCategories.js
@@ -1,4 +1,3 @@
-// /util/autoCreateDefaultCategories.js
 import HabitCategory, { validateCategory } from "../models/habitCategory.js";
 import { logError, logInfo } from "../util/logging.js";
 import validationErrorMessage from "../util/validationErrorMessage.js";


### PR DESCRIPTION
Description:

We've implemented a new route for creating default categories at api/habit-categories/autoCreateDefaultCategories. This route can be used by the front end to trigger category creation in cases where the categories aren't automatically created during user sign-in.

To support this, we created the autoCreateCategoriesController, which invokes the auxiliary function responsible for creating categories. Additionally, we updated the getCategories tests to ensure an appropriate message is returned when a user has no categories.

We also modified the logout functionality to support the web version of the application, which does not use cookies but instead authenticates using a token in the header. The logout process now passes through the route with the authentication middleware, and the corresponding tests have been updated accordingly.