### PR TITLE
Update Default Goal Value for Categories

### DIFF
--- a/models/habitCategory.js
+++ b/models/habitCategory.js
@@ -21,7 +21,7 @@ const habitCategorySchema = new mongoose.Schema({
   },
   dailyGoal: {
     type: Number,
-    default: 0,
+    default: 55,
   },
 });
 


### PR DESCRIPTION
This pull request introduces a minor yet impactful change to improve the initial visualization of the charts.

Updated the default goal value for each category from 0 to 55.
This ensures that the charts display meaningful data even for new users or categories without pre-set goals, enhancing the user experience.